### PR TITLE
Add configuration file to save selected mode and version

### DIFF
--- a/src/FlaUInspect/FlaUInspect.csproj
+++ b/src/FlaUInspect/FlaUInspect.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Reference Include="Accessibility" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
@@ -176,6 +177,9 @@
     <Resource Include="Resources\Calendar.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FlaUI.Core">
+      <Version>3.2.0</Version>
+    </PackageReference>
     <PackageReference Include="FlaUI.UIA2">
       <Version>3.2.0</Version>
     </PackageReference>

--- a/src/FlaUInspect/Views/MainWindow.xaml
+++ b/src/FlaUInspect/Views/MainWindow.xaml
@@ -24,6 +24,7 @@
             <Menu DockPanel.Dock="Top">
                 <MenuItem Header="_File">
                     <MenuItem Header="_New Instance" Command="{Binding StartNewInstanceCommand}" />
+                    <MenuItem Header="_New Instance with version selection" Command="{Binding StartNewInstanceWithVersionSelectionCommand}" />
                     <MenuItem Header="_Capture selected item" Command="{Binding CaptureSelectedItemCommand}" />
                     <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}" InputGestureText="F5" />
                     <Separator />


### PR DESCRIPTION
The UIA version and selected modes are saved in the App.config. If the mode and version is set at application start, then both is set. Also when switching the mode it is saved in the config. Additionally, when the UIA version wants to be changed then the new menu entry is selected